### PR TITLE
use the vender/bin/luya instead of the fallback method, fixes issue #2

### DIFF
--- a/luya.sh
+++ b/luya.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-cd /app/public_html/
-exec php index.php "$@"
+cd /app
+vendor/bin/luya "$@"


### PR DESCRIPTION
### What are you changing/introducing
Update the **luya.sh** script to use the `vendor/bin/luya` script which links back to `luyadev/luya-core/bin/luya*` instead of the fallback method

### What is the reason for changing/introducing
BlockImporter is not able to parse blocks when running the luya import from `docker-compose` 
`docker-compose exec luya_php luya import`

this closes #2

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #2
